### PR TITLE
Fixes filname in command declaration

### DIFF
--- a/deployments/cf/manifest.yml
+++ b/deployments/cf/manifest.yml
@@ -3,6 +3,6 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/binary-buildpack.git
     memory: 64M
-    command: ./deployments/cf/entrypoint-cf.sh
+    command: ./deployments/cf/entrypoint.sh
     services:
       - my-storage


### PR DESCRIPTION
The filename in the cf entrypoint was entrypoint-cf.sh, but the file is named entrypoint.sh actually. 