### PR TITLE
Fixed a problem when using AWS S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ WORKDIR /app
 COPY . ./
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -a -installsuffix cgo -o bin/s3manager ./cmd/s3manager
 
-FROM scratch
+FROM alpine
 WORKDIR /app
 COPY --from=builder /app/bin/s3manager ./
 COPY --from=builder /app/web ./web/
 COPY --from=builder /etc/passwd /etc/passwd
+RUN apk update && apk add --no-cache ca-certificates
 USER app
 EXPOSE 8080
 ENTRYPOINT ["./s3manager"]

--- a/internal/app/s3manager/create_object.go
+++ b/internal/app/s3manager/create_object.go
@@ -26,7 +26,7 @@ func HandleCreateObject(s3 S3) http.HandlerFunc {
 		defer file.Close()
 
 		opts := minio.PutObjectOptions{ContentType: "application/octet-stream"}
-		_, err = s3.PutObject(bucketName, header.Filename, file, 1, opts)
+		_, err = s3.PutObject(bucketName, header.Filename, file, -1, opts)
 		if err != nil {
 			handleHTTPError(w, fmt.Errorf("error putting object: %w", err))
 			return


### PR DESCRIPTION
Hello, this is a fix for some errors I encountered when using AWS S3 as a backend.

1. The CA certificate was not included in the container image and the certificate verification failed. The certificate is now obtained during the image build process.

2. The file size was fixed at 1 when doing the upload. This seemed to work fine in minio, but in AWS S3, when I checked the file size after upload, it was 1 byte. Following the comments of minio-go, I changed the file size to -1 for uploading.

https://github.com/minio/minio-go/blob/3316e6abb590e554a062be8c54efdd2e1dec282f/api-put-object.go#L204-L206

Also, the library seems to use /tmp when performing multipart upload, but the scratch image cannot write to /tmp and an error occurs, so I changed it to use the alpine image. (There is no strong reason to use alpine, so please change it as needed.)